### PR TITLE
Cargo format, clippy recommendations

### DIFF
--- a/src/compressor.rs
+++ b/src/compressor.rs
@@ -8,7 +8,7 @@ pub struct Compressor {
   pub gain_rt: f32,
   pub gain_average: f32,
 
-  pub threshold: f32
+  pub threshold: f32,
 }
 
 fn calc_tau(sample_rate: f32, time_ms: f32) -> f32 {
@@ -24,7 +24,7 @@ fn limiter(input: f32, threshold: f32) -> f32 {
 fn ar_avg(avg: f32, at: f32, rt: f32, input: f32) -> f32 {
   let tau = if input > avg { at } else { rt };
 
-  (1.0 - tau) * avg + tau * input
+  (1.0 - tau).mul_add(avg, tau * input)
 }
 
 impl Compressor {

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1,18 +1,36 @@
+use cpal::{
+  traits::{DeviceTrait, HostTrait, StreamTrait},
+  Device, Stream,
+};
 use std::sync::atomic::Ordering;
-use cpal::{traits::{DeviceTrait, HostTrait, StreamTrait}, Device, Stream};
 
-use crate::{compressor::Compressor, gui::{CURR_THRESHOLD, DEFAULT_ATTACK, DEFAULT_RELEASE}};
+use crate::{
+  compressor::Compressor,
+  gui::{CURR_THRESHOLD, DEFAULT_ATTACK, DEFAULT_RELEASE},
+};
 
 pub fn get_devices() -> Vec<Device> {
-  cpal::default_host().devices().expect("Could not find devices").collect()
+  cpal::default_host()
+    .devices()
+    .expect("Could not find devices")
+    .collect()
 }
 
-pub fn create_stream(input_device: &Device, output_device: &Device, threshold: f32) -> Option<(Stream, Stream)> {
+pub fn create_stream(
+  input_device: &Device,
+  output_device: &Device,
+  threshold: f32,
+) -> Option<(Stream, Stream)> {
   let input_config: cpal::StreamConfig = input_device.default_input_config().ok()?.into();
   let output_config: cpal::StreamConfig = output_device.default_output_config().ok()?.into();
 
-  let mut comp = Compressor::new(input_config.sample_rate.0 as f32, threshold, DEFAULT_ATTACK, DEFAULT_RELEASE);
-  
+  let mut comp = Compressor::new(
+    input_config.sample_rate.0 as f32,
+    threshold,
+    DEFAULT_ATTACK,
+    DEFAULT_RELEASE,
+  );
+
   let err_fn = |err| eprintln!("An error occurred on the output audio stream: {}", err);
 
   let latency = 100.0;
@@ -40,15 +58,16 @@ pub fn create_stream(input_device: &Device, output_device: &Device, threshold: f
 
   let output_data_fn = move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
     for sample in data {
-      *sample = match consumer.pop() {
-        Some(s) => s,
-        None => 0.0,
-      };
+      *sample = consumer.pop().unwrap_or(0.0);
     }
   };
 
-  let input_stream = input_device.build_input_stream(&input_config, input_data_fn, err_fn).expect("Error building input stream");
-  let output_stream = output_device.build_output_stream(&output_config, output_data_fn, err_fn).expect("Error building output stream");
+  let input_stream = input_device
+    .build_input_stream(&input_config, input_data_fn, err_fn)
+    .expect("Error building input stream");
+  let output_stream = output_device
+    .build_output_stream(&output_config, output_data_fn, err_fn)
+    .expect("Error building output stream");
 
   input_stream.play().expect("Could not play input stream");
   output_stream.play().expect("Could not play output stream");


### PR DESCRIPTION
I applied several cargo clippy recommendations and formatted the code. This ensures the code chosen is "best practice" which may or may not be important to you in certain places, so feel free to take Clippy's recommendations with a grain of salt. 

This is the output of default `cargo fmt` plus some clippy recommendations that helped with speed slightly.